### PR TITLE
minor bugfixes and block on OS X execution

### DIFF
--- a/screeny
+++ b/screeny
@@ -167,7 +167,7 @@ detectWMTheme () {
 }
 
 detectFont () {
-	font=$(cat $HOME/.minttyrc | grep '^Font=.*' | grep -o '[0-9a-Z ]*$')
+	font=$(cat $HOME/.minttyrc | grep '^Font=.*' | grep -o '[0-9A-Za-z ]*$')
 	[[ "$debug" -eq "1" ]] && Debug "Finding Font.... Found as: '$font'"
 }
 


### PR DESCRIPTION
No major changes.
I added a color change to the end of screeny to ensure that it returns the terminal's color back to normal.
I also added a condition block to prevent accidental execution on Darwin (OS X) systems.
Finally, I made the regex statement in the font detection section a little more generic.
