### PR TITLE
Fixes Resolution Output.

### DIFF
--- a/screeny
+++ b/screeny
@@ -90,8 +90,8 @@ detectHDD () {
 }
 
 detectResolution () {
-	width=`wmic desktopmonitor get screenwidth | grep -vE '[a-z]+' | tr -d '\r\n '`
-	height=`wmic desktopmonitor get screenheight | grep -vE '[a-z]+' | tr -d '\r\n '`
+	width=`wmic path Win32_VideoController get CurrentHorizontalResolution /value | awk -F '=' '{print $2}' | tr -d '\r\n '`
+	height=`wmic path Win32_VideoController get CurrentVerticalResolution /value | awk -F '=' '{print $2}' | tr -d '\r\n '`
 	[[ "$debug" -eq "1" ]] && Debug "Finding Screen Resolution.... Found as: '$width / $height'"
 }
 


### PR DESCRIPTION
- Fixes the resolution output by using the Video Controller's reported resolution instead of the monitor's reported. This is because the `desktopmonitor` relates to the monitor (and in my case output nothing).
